### PR TITLE
ignore the IntelliJ IDE configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ npm-debug.log
 # secrets files as long as you replace their contents by environment
 # variables.
 /config/*.secret.exs
+
+# Ingore the whole configuration files from the .idea folder
+/.idea


### PR DESCRIPTION
### Summary

   - Add an ignore rule into the `.gitignore` file to skip to trace the change from the `.idea` directory.